### PR TITLE
Autoconfirm install for nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN chmod +x /setup_6.x && \
     sync && \
     /setup_6.x && \
     apt-get update && \
-    apt-get install nodejs && \
+    apt-get install -y nodejs && \
     npm install -g forever
 
 


### PR DESCRIPTION
This was failing for me, I guess because the state of the package repository has changed and now apt wants to ask first.