### PR TITLE
Add docker-compose.sboldb.yml to run SynBioHub on sbol-db

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ To run the base configuration:
 ### With Explorer
 To add [SBOLExplorer](https://github.com/michael13162/SBOLExplorer), add the `docker-compose.explorer.yml` to the main docker-compose, i.e. for step 3 run `docker-compose -f ./synbiohub-docker/docker-compose.yml -f ./synbiohub-docker/docker-compose.explorer.yml up`
 
+### With sbol-db instead of Virtuoso
+To run SynBioHub on [sbol-db](https://github.com/marpaia/sbol-db) instead of Virtuoso, use `docker-compose.sboldb.yml` in place of the base `docker-compose.yml`:
+
+`docker-compose -f ./synbiohub-docker/docker-compose.sboldb.yml up`
+
+This stack replaces the Virtuoso service with sbol-db (backed by Postgres). sbol-db answers on the `virtuoso` network alias at port 8890 and exposes the same HTTP SPARQL endpoints, so SynBioHub's triplestore configuration is unchanged — the triplestore is selected purely by which compose file you use. It requires a SynBioHub image with standards-compliant SPARQL (the triplestore-agnostic query fixes), which the published `snapshot-standalone` image carries.
+
 ### With Plugins
 To add plugins to the configuration change step 3 to: `docker-compose --f ./synbiohub-docker/docker-compose.yml -f ./synbiohub-docker/docker-compose.explorer.yml -f ./synbiohub-docker/docker-compose.<Plugin 1 File Name>.yml -f ./synbiohub-docker/docker-compose.<Plugin 2 File Name>.yml up`
 

--- a/docker-compose.sboldb.yml
+++ b/docker-compose.sboldb.yml
@@ -1,0 +1,92 @@
+# SynBioHub backed by sbol-db instead of Virtuoso.
+#
+# Drop-in alternative to docker-compose.yml: the sbol-db service answers on the
+# `virtuoso` network alias at port 8890 and speaks the same HTTP SPARQL surface
+# (/sparql, /sparql-auth, /sparql-graph-crud-auth/), so SynBioHub's stock
+# triplestore configuration is used unchanged.
+#
+#   docker compose -f docker-compose.sboldb.yml up -d
+#
+# Requires a SynBioHub image whose SPARQL is standards-compliant (the
+# triplestore-agnostic query fixes); the published snapshot-standalone image
+# carries them.
+version: '3.2'
+
+services:
+    autoheal:
+        restart: always
+        image: willfarrell/autoheal
+        environment:
+            - AUTOHEAL_CONTAINER_LABEL=all
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
+    postgres:
+        image: postgres:17
+        environment:
+            POSTGRES_USER: sbol
+            POSTGRES_PASSWORD: sbol
+            POSTGRES_DB: sbol
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U sbol -d sbol"]
+            interval: 5s
+            timeout: 5s
+            retries: 30
+        volumes:
+            - type: volume
+              source: pgdata
+              target: /var/lib/postgresql/data
+        restart: always
+    sboldb-migrate:
+        image: ghcr.io/marpaia/sbol-db:v0.1.1
+        depends_on:
+            postgres:
+                condition: service_healthy
+        environment:
+            DATABASE_URL: postgres://sbol:sbol@postgres:5432/sbol
+        command: ["db", "migrate"]
+        restart: "no"
+    sboldb:
+        image: ghcr.io/marpaia/sbol-db:v0.1.1
+        depends_on:
+            sboldb-migrate:
+                condition: service_completed_successfully
+        environment:
+            DATABASE_URL: postgres://sbol:sbol@postgres:5432/sbol
+            SBOL_DB_SPARQL_AUTH_USER: dba
+            SBOL_DB_SPARQL_AUTH_PASSWORD: dba
+            # Trusted docker network: skip write-endpoint auth so the
+            # 401-challenge (SynBioHub uploads with sendImmediately:false) can't
+            # close large chunked uploads mid-body (surfaces as write EPIPE).
+            SBOL_DB_SPARQL_AUTH_DISABLED: "true"
+        command: ["server", "--bind", "0.0.0.0:8890"]
+        # Verbatim-triplestore mode does not use sbol-db's ontology tables, so
+        # the health check must not require an ontology load.
+        healthcheck:
+            test: ["CMD", "/usr/local/bin/sbol-db", "db", "doctor", "--require-ontologies", ""]
+            interval: 5s
+            timeout: 10s
+            retries: 30
+        ports:
+            - "8890:8890"
+        # Answer at the hostname Virtuoso used so SynBioHub's triplestore config
+        # is identical across backends.
+        networks:
+            default:
+                aliases:
+                    - virtuoso
+        restart: always
+    synbiohub:
+        image: synbiohub/synbiohub:snapshot-standalone
+        depends_on:
+            - sboldb
+        ports:
+            - "7777:7777"
+        volumes:
+            - type: volume
+              source: sbh
+              target: /mnt
+        restart: always
+
+volumes:
+    pgdata:
+    sbh:


### PR DESCRIPTION
A drop-in alternative to docker-compose.yml that replaces the Virtuoso service with sbol-db (backed by Postgres). sbol-db answers on the virtuoso network alias at port 8890 and exposes the same HTTP SPARQL endpoints (`/sparql`, `/sparql-auth`, `/sparql-graph-crud-auth/`), so SynBioHub's triplestore configuration is unchanged and the triplestore is selected purely by which compose file docker-compose is given.

After this merges to master, we need to make sure to also update the `snapshot branch` (that's the branch `tests/start_containers.sh` clones). This blocks merging https://github.com/SynBioHub/synbiohub/pull/1743.