### PR TITLE
Add sbol-db as a parallel search backend to SBOLExplorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,11 @@ docker compose \
 The search overlay starts a second, network-internal sbol-db listener at
 `http://explorer:13162/`. Both listeners share the same process, database,
 search index, maintenance workers, and shutdown lifecycle. Port 13162 is not
-published to the host in this topology. The default sbol-db image is the
-immutable `v0.1.2` release, which includes both the compatibility listener and
-the bundled ontology. Before the listener starts, a one-shot service loads the
-checksum-pinned Sequence Ontology snapshot bundled in the sbol-db image. Native
-text indexing can therefore expand SBOL role IRIs to SO labels and synonyms
-without relying on a mutable network download. The health check requires that
-load to be present.
+published to the host in this topology. The default sbol-db image includes both
+the compatibility listener and a bundled Sequence Ontology snapshot. Before the
+listener starts, a one-shot service loads that snapshot so native text indexing
+can expand SBOL role IRIs to SO labels and synonyms without a network download.
+The health check requires that load to be present.
 
 Worker-enabled sbol-db comparison rows default to one maintenance worker so
 full lexical and vector reconciliations cannot compete for memory. Set
@@ -71,7 +69,7 @@ example:
 ```sh
 COMPOSE_PROJECT_NAME=sbh-search-eval \
 SYNBIOHUB_IMAGE=synbiohub/synbiohub:sbol-db-and-explorer \
-SBOLDB_IMAGE=ghcr.io/marpaia/sbol-db:v0.1.2@sha256:e6bf296de9c170f69c2e87a1dcaa01f2a6d6de5941907e2860b3e6065d35edcd \
+SBOLDB_IMAGE=your-sbol-db-image \
 SYNBIOHUB_PORT=17777 \
 TRIPLESTORE_PORT=18890 \
 docker compose \

--- a/README.md
+++ b/README.md
@@ -1,10 +1,91 @@
-Terminal
-cd into folder to put synbiohub-docker in
-git clone -b snapshot <https://github.com/SynBioHub/synbiohub-docker.git>
-docker-compose -f ./synbiohub-docker/docker-compose.yml up
-Remember to remove the old image and container before using a new one. Otherwise, Docker will just continue to use the old one. 
-For spoofing purposes: on setup, change URI prefix to https://synbiohub.org/
+# SynBioHub Docker topologies
 
-To run on [sbol-db](https://github.com/marpaia/sbol-db) instead of Virtuoso, use `docker-compose.sboldb.yml` in place of `docker-compose.yml`:
-docker-compose -f ./synbiohub-docker/docker-compose.sboldb.yml up
-sbol-db answers on the `virtuoso` network alias at port 8890 and exposes the same HTTP SPARQL endpoints, so SynBioHub's triplestore configuration is unchanged — the triplestore is selected purely by which compose file you use.
+Clone this repository and run one of the Compose combinations below. The
+search-backend comparison deliberately enables strict Explorer mode:
+`SBH_EXPLORER_FALLBACK=false` makes an unavailable or failing Explorer endpoint
+visible instead of silently retrying the same query against the triplestore.
+
+| Topology | SynBioHub store | SynBioHub Explorer endpoint | Compose files |
+| --- | --- | --- | --- |
+| `virtuoso-explorer` | Virtuoso | SBOLExplorer | `docker-compose.yml` + `docker-compose.explorer.yml` |
+| `sboldb-explorer` | sbol-db (store only) | SBOLExplorer | `docker-compose.sboldb.yml` + `docker-compose.sboldb-store-only.yml` + `docker-compose.explorer.yml` |
+| `sboldb-native` | sbol-db | sbol-db compatibility listener | `docker-compose.sboldb.yml` + `docker-compose.sboldb-search.yml` |
+
+## Virtuoso and SBOLExplorer
+
+```sh
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.explorer.yml \
+  up -d
+```
+
+## sbol-db and SBOLExplorer
+
+```sh
+docker compose \
+  -f docker-compose.sboldb.yml \
+  -f docker-compose.sboldb-store-only.yml \
+  -f docker-compose.explorer.yml \
+  up -d
+```
+
+sbol-db answers on the `virtuoso` network alias at port 8890 and exposes the
+HTTP SPARQL endpoints expected by SynBioHub, so the SynBioHub triplestore
+configuration is unchanged. The store-only overlay disables sbol-db's embedded
+worker and native search-maintenance deployment because the separate
+SBOLExplorer container owns that role; this prevents duplicate, unused index
+rebuilds during store writes.
+
+## sbol-db as both store and Explorer
+
+```sh
+docker compose \
+  -f docker-compose.sboldb.yml \
+  -f docker-compose.sboldb-search.yml \
+  up -d
+```
+
+The search overlay starts a second, network-internal sbol-db listener at
+`http://explorer:13162/`. Both listeners share the same process, database,
+search index, maintenance workers, and shutdown lifecycle. Port 13162 is not
+published to the host in this topology. Until this compatibility listener and
+the bundled ontology ship in the default sbol-db release, set `SBOLDB_IMAGE` to
+a candidate image containing both. Before the listener starts, a one-shot
+service loads the checksum-pinned Sequence Ontology snapshot bundled in the
+sbol-db image. Native text indexing can therefore expand SBOL role IRIs to SO
+labels and synonyms without relying on a mutable network download. The health
+check requires that load to be present.
+
+Worker-enabled sbol-db comparison rows default to one maintenance worker so
+full lexical and vector reconciliations cannot compete for memory. Set
+`SBOLDB_WORKER_CONCURRENCY` explicitly when evaluating a larger production
+allocation; the external-SBOLExplorer row uses the store-only overlay and
+starts no sbol-db worker.
+
+## Reproducible candidate images and isolated runs
+
+Every image and published port can be overridden without editing YAML. For
+example:
+
+```sh
+COMPOSE_PROJECT_NAME=sbh-search-eval \
+SYNBIOHUB_IMAGE=synbiohub/synbiohub:sbol-db-and-explorer \
+SBOLDB_IMAGE=sbol-db:sbol-db-and-explorer \
+SYNBIOHUB_PORT=17777 \
+TRIPLESTORE_PORT=18890 \
+docker compose \
+  -f docker-compose.sboldb.yml \
+  -f docker-compose.sboldb-search.yml \
+  up -d
+```
+
+Use a distinct `COMPOSE_PROJECT_NAME` for every comparison row so volumes and
+networks cannot leak state between backends. Record immutable image digests in
+test reports even when convenient local tags are supplied on the command line.
+SBOLExplorer is intentionally run as `linux/amd64` because its checked-in
+vsearch executable is x86-64-only; override `SBOLEXPLORER_PLATFORM` only after
+replacing that binary with a native or multi-architecture build.
+
+On initial SynBioHub setup, use `https://synbiohub.org/` as the URI prefix when
+testing production-style URL spoofing.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # SynBioHub Docker topologies
 
-Clone this repository and run one of the Compose combinations below. The
-search-backend comparison deliberately enables strict Explorer mode:
-`SBH_EXPLORER_FALLBACK=false` makes an unavailable or failing Explorer endpoint
-visible instead of silently retrying the same query against the triplestore.
+Clone this repository and run one of the Compose combinations below. The search-backend comparison deliberately enables strict Explorer mode: `SBH_EXPLORER_FALLBACK=false` makes an unavailable or failing Explorer endpoint visible instead of silently retrying the same query against the triplestore.
 
 | Topology | SynBioHub store | SynBioHub Explorer endpoint | Compose files |
 | --- | --- | --- | --- |
@@ -30,12 +27,7 @@ docker compose \
   up -d
 ```
 
-sbol-db answers on the `virtuoso` network alias at port 8890 and exposes the
-HTTP SPARQL endpoints expected by SynBioHub, so the SynBioHub triplestore
-configuration is unchanged. The store-only overlay disables sbol-db's embedded
-worker and native search-maintenance deployment because the separate
-SBOLExplorer container owns that role; this prevents duplicate, unused index
-rebuilds during store writes.
+sbol-db answers on the `virtuoso` network alias at port 8890 and exposes the HTTP SPARQL endpoints expected by SynBioHub, so the SynBioHub triplestore configuration is unchanged. The store-only overlay disables sbol-db's embedded worker and native search-maintenance deployment because the separate SBOLExplorer container owns that role; this prevents duplicate, unused index rebuilds during store writes.
 
 ## sbol-db as both store and Explorer
 
@@ -46,25 +38,13 @@ docker compose \
   up -d
 ```
 
-The search overlay starts a second, network-internal sbol-db listener at
-`http://explorer:13162/`. Both listeners share the same process, database,
-search index, maintenance workers, and shutdown lifecycle. Port 13162 is not
-published to the host in this topology. The default sbol-db image includes both
-the compatibility listener and a bundled Sequence Ontology snapshot. Before the
-listener starts, a one-shot service loads that snapshot so native text indexing
-can expand SBOL role IRIs to SO labels and synonyms without a network download.
-The health check requires that load to be present.
+The search overlay starts a second, network-internal sbol-db listener at `http://explorer:13162/`. Both listeners share the same process, database, search index, maintenance workers, and shutdown lifecycle. Port 13162 is not published to the host in this topology. The default sbol-db image includes both the compatibility listener and a bundled Sequence Ontology snapshot. Before the listener starts, a one-shot service loads that snapshot so native text indexing can expand SBOL role IRIs to SO labels and synonyms without a network download. The health check requires that load to be present.
 
-Worker-enabled sbol-db comparison rows default to one maintenance worker so
-full lexical and vector reconciliations cannot compete for memory. Set
-`SBOLDB_WORKER_CONCURRENCY` explicitly when evaluating a larger production
-allocation; the external-SBOLExplorer row uses the store-only overlay and
-starts no sbol-db worker.
+Worker-enabled sbol-db comparison rows default to one maintenance worker so full lexical and vector reconciliations cannot compete for memory. Set `SBOLDB_WORKER_CONCURRENCY` explicitly when evaluating a larger production allocation; the external-SBOLExplorer row uses the store-only overlay and starts no sbol-db worker.
 
 ## Reproducible image overrides and isolated runs
 
-Every image and published port can be overridden without editing YAML. For
-example:
+Every image and published port can be overridden without editing YAML. For example:
 
 ```sh
 COMPOSE_PROJECT_NAME=sbh-search-eval \
@@ -78,12 +58,6 @@ docker compose \
   up -d
 ```
 
-Use a distinct `COMPOSE_PROJECT_NAME` for every comparison row so volumes and
-networks cannot leak state between backends. Record immutable image digests in
-test reports even when convenient local tags are supplied on the command line.
-SBOLExplorer is intentionally run as `linux/amd64` because its checked-in
-vsearch executable is x86-64-only; override `SBOLEXPLORER_PLATFORM` only after
-replacing that binary with a native or multi-architecture build.
+Use a distinct `COMPOSE_PROJECT_NAME` for every comparison row so volumes and networks cannot leak state between backends. Record immutable image digests in test reports even when convenient local tags are supplied on the command line. SBOLExplorer is intentionally run as `linux/amd64` because its checked-in vsearch executable is x86-64-only; override `SBOLEXPLORER_PLATFORM` only after replacing that binary with a native or multi-architecture build.
 
-On initial SynBioHub setup, use `https://synbiohub.org/` as the URI prefix when
-testing production-style URL spoofing.
+On initial SynBioHub setup, use `https://synbiohub.org/` as the URI prefix when testing production-style URL spoofing.

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ docker compose \
 The search overlay starts a second, network-internal sbol-db listener at
 `http://explorer:13162/`. Both listeners share the same process, database,
 search index, maintenance workers, and shutdown lifecycle. Port 13162 is not
-published to the host in this topology. Until this compatibility listener and
-the bundled ontology ship in the default sbol-db release, set `SBOLDB_IMAGE` to
-a candidate image containing both. Before the listener starts, a one-shot
-service loads the checksum-pinned Sequence Ontology snapshot bundled in the
-sbol-db image. Native text indexing can therefore expand SBOL role IRIs to SO
-labels and synonyms without relying on a mutable network download. The health
-check requires that load to be present.
+published to the host in this topology. The default sbol-db image is the
+immutable `v0.1.2` release, which includes both the compatibility listener and
+the bundled ontology. Before the listener starts, a one-shot service loads the
+checksum-pinned Sequence Ontology snapshot bundled in the sbol-db image. Native
+text indexing can therefore expand SBOL role IRIs to SO labels and synonyms
+without relying on a mutable network download. The health check requires that
+load to be present.
 
 Worker-enabled sbol-db comparison rows default to one maintenance worker so
 full lexical and vector reconciliations cannot compete for memory. Set
@@ -63,7 +63,7 @@ full lexical and vector reconciliations cannot compete for memory. Set
 allocation; the external-SBOLExplorer row uses the store-only overlay and
 starts no sbol-db worker.
 
-## Reproducible candidate images and isolated runs
+## Reproducible image overrides and isolated runs
 
 Every image and published port can be overridden without editing YAML. For
 example:
@@ -71,7 +71,7 @@ example:
 ```sh
 COMPOSE_PROJECT_NAME=sbh-search-eval \
 SYNBIOHUB_IMAGE=synbiohub/synbiohub:sbol-db-and-explorer \
-SBOLDB_IMAGE=sbol-db:sbol-db-and-explorer \
+SBOLDB_IMAGE=ghcr.io/marpaia/sbol-db:v0.1.2@sha256:e6bf296de9c170f69c2e87a1dcaa01f2a6d6de5941907e2860b3e6065d35edcd \
 SYNBIOHUB_PORT=17777 \
 TRIPLESTORE_PORT=18890 \
 docker compose \

--- a/docker-compose.explorer.yml
+++ b/docker-compose.explorer.yml
@@ -1,26 +1,49 @@
 services:
     explorer:
-        image: myersresearchgroup/sbolexplorer:snapshot-synbiohub
+        image: ${SBOLEXPLORER_IMAGE:-myersresearchgroup/sbolexplorer:snapshot-synbiohub}
+        # The repository currently vendors an x86-64-only vsearch executable.
+        platform: ${SBOLEXPLORER_PLATFORM:-linux/amd64}
         privileged: true 
         ports:
-            - "13162:13162"
+            - "${EXPLORER_PORT:-13162}:13162"
         depends_on:
-            - elasticsearch
-            - synbiohub
+            elasticsearch:
+                condition: service_healthy
+            synbiohub:
+                condition: service_healthy
+        healthcheck:
+            test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:13162/info', timeout=5)"]
+            interval: 5s
+            timeout: 10s
+            retries: 60
+            start_period: 30s
         volumes:
             - type: volume
               source: explorer
               target: /mnt
+        restart: always
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
-        depends_on: 
-            - virtuoso
+        image: ${ELASTICSEARCH_IMAGE:-docker.elastic.co/elasticsearch/elasticsearch:6.3.2}
+        environment:
+            - discovery.type=single-node
+            - ES_JAVA_OPTS=-Xms512m -Xmx512m
         ports:
-            - "9200:9200"
+            - "${ELASTICSEARCH_PORT:-9200}:9200"
+        healthcheck:
+            test: ["CMD-SHELL", "curl -fsS 'http://127.0.0.1:9200/_cluster/health?wait_for_status=yellow&timeout=1s' >/dev/null"]
+            interval: 5s
+            timeout: 5s
+            retries: 60
+            start_period: 20s
         volumes:
             - type: volume
               source: esdata
               target: /usr/share/elasticsearch/data
+    synbiohub:
+        environment:
+            SBH_USE_EXPLORER: "true"
+            SBH_EXPLORER_ENDPOINT: http://explorer:13162/
+            SBH_EXPLORER_FALLBACK: "false"
 volumes:
     esdata:
     explorer:

--- a/docker-compose.sboldb-search.yml
+++ b/docker-compose.sboldb-search.yml
@@ -1,0 +1,64 @@
+# Enable sbol-db's network-internal SBOLExplorer-compatible listener while the
+# same process continues to serve SynBioHub's Virtuoso-compatible store API.
+# Layer this only on docker-compose.sboldb.yml:
+#
+#   docker compose \
+#     -f docker-compose.sboldb.yml \
+#     -f docker-compose.sboldb-search.yml up -d
+
+services:
+    # Load the immutable SO snapshot bundled in the sbol-db image before the
+    # native search worker can build its first index. This gives role IRIs the
+    # same label/synonym vocabulary SBOLExplorer applies to every document,
+    # without introducing a live ontology download into a comparison run.
+    sboldb-ontology:
+        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.1}
+        depends_on:
+            sboldb-migrate:
+                condition: service_completed_successfully
+        environment:
+            DATABASE_URL: postgres://sbol:sbol@postgres:5432/sbol
+        command:
+            - ontology
+            - load-file
+            - /opt/sbol-db/ontologies/so.obo
+            - --prefix
+            - SO
+            - --name
+            - Sequence Ontology (image-pinned)
+        restart: "no"
+    sboldb:
+        depends_on:
+            sboldb-ontology:
+                condition: service_completed_successfully
+        command:
+            - server
+            - --bind
+            - 0.0.0.0:8890
+            - --explorer-bind
+            - 0.0.0.0:13162
+            # Full-corpus reconciliation holds substantial transient state.
+            # Keep the comparison topology deterministic and prevent the
+            # lexical and vector rebuild jobs from competing for memory.
+            - --worker-concurrency
+            - ${SBOLDB_WORKER_CONCURRENCY:-1}
+        expose:
+            - "13162"
+        healthcheck:
+            test: ["CMD", "/usr/local/bin/sbol-db", "db", "doctor", "--require-ontologies", "SO"]
+            interval: 5s
+            timeout: 10s
+            retries: 30
+        networks:
+            default:
+                aliases:
+                    - virtuoso
+                    - explorer
+    synbiohub:
+        environment:
+            SBH_USE_EXPLORER: "true"
+            SBH_EXPLORER_ENDPOINT: http://explorer:13162/
+            SBH_EXPLORER_FALLBACK: "false"
+        depends_on:
+            sboldb:
+                condition: service_healthy

--- a/docker-compose.sboldb-search.yml
+++ b/docker-compose.sboldb-search.yml
@@ -12,7 +12,7 @@ services:
     # same label/synonym vocabulary SBOLExplorer applies to every document,
     # without introducing a live ontology download into a comparison run.
     sboldb-ontology:
-        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.1}
+        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.2@sha256:e6bf296de9c170f69c2e87a1dcaa01f2a6d6de5941907e2860b3e6065d35edcd}
         depends_on:
             sboldb-migrate:
                 condition: service_completed_successfully

--- a/docker-compose.sboldb-search.yml
+++ b/docker-compose.sboldb-search.yml
@@ -12,7 +12,7 @@ services:
     # same label/synonym vocabulary SBOLExplorer applies to every document,
     # without introducing a live ontology download into a comparison run.
     sboldb-ontology:
-        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.2@sha256:e6bf296de9c170f69c2e87a1dcaa01f2a6d6de5941907e2860b3e6065d35edcd}
+        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.2}
         depends_on:
             sboldb-migrate:
                 condition: service_completed_successfully

--- a/docker-compose.sboldb-store-only.yml
+++ b/docker-compose.sboldb-store-only.yml
@@ -1,0 +1,13 @@
+# Disable sbol-db's native search-maintenance worker when a separate
+# SBOLExplorer container owns the Explorer role. Layer this between the sbol-db
+# store profile and docker-compose.explorer.yml:
+#
+#   docker compose \
+#     -f docker-compose.sboldb.yml \
+#     -f docker-compose.sboldb-store-only.yml \
+#     -f docker-compose.explorer.yml up -d
+
+services:
+    sboldb:
+        environment:
+            SBOL_DB_WORKER_DISABLED: "true"

--- a/docker-compose.sboldb.yml
+++ b/docker-compose.sboldb.yml
@@ -13,13 +13,13 @@
 services:
     autoheal:
         restart: always
-        image: willfarrell/autoheal
+        image: ${AUTOHEAL_IMAGE:-willfarrell/autoheal}
         environment:
             - AUTOHEAL_CONTAINER_LABEL=all
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
     postgres:
-        image: postgres:17
+        image: ${POSTGRES_IMAGE:-postgres:17}
         environment:
             POSTGRES_USER: sbol
             POSTGRES_PASSWORD: sbol
@@ -35,7 +35,7 @@ services:
               target: /var/lib/postgresql/data
         restart: always
     sboldb-migrate:
-        image: ghcr.io/marpaia/sbol-db:v0.1.1
+        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.1}
         depends_on:
             postgres:
                 condition: service_healthy
@@ -44,7 +44,7 @@ services:
         command: ["db", "migrate"]
         restart: "no"
     sboldb:
-        image: ghcr.io/marpaia/sbol-db:v0.1.1
+        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.1}
         depends_on:
             sboldb-migrate:
                 condition: service_completed_successfully
@@ -52,6 +52,10 @@ services:
             DATABASE_URL: postgres://sbol:sbol@postgres:5432/sbol
             SBOL_DB_SPARQL_AUTH_USER: dba
             SBOL_DB_SPARQL_AUTH_PASSWORD: dba
+            # Worker-enabled full-corpus comparisons trigger both lexical and
+            # vector maintenance. Serialize those memory-heavy jobs by default;
+            # the external-Explorer overlay disables this worker altogether.
+            SBOL_DB_WORKER_CONCURRENCY: ${SBOLDB_WORKER_CONCURRENCY:-1}
             # Trusted docker network: skip write-endpoint auth so the
             # 401-challenge (SynBioHub uploads with sendImmediately:false) can't
             # close large chunked uploads mid-body (surfaces as write EPIPE).
@@ -65,7 +69,7 @@ services:
             timeout: 10s
             retries: 30
         ports:
-            - "8890:8890"
+            - "${TRIPLESTORE_PORT:-8890}:8890"
         # Answer at the hostname Virtuoso used so SynBioHub's triplestore config
         # is identical across backends.
         networks:
@@ -74,11 +78,11 @@ services:
                     - virtuoso
         restart: always
     synbiohub:
-        image: synbiohub/synbiohub:snapshot-standalone
+        image: ${SYNBIOHUB_IMAGE:-synbiohub/synbiohub:snapshot-standalone}
         depends_on:
             - sboldb
         ports:
-            - "7777:7777"
+            - "${SYNBIOHUB_PORT:-7777}:7777"
         volumes:
             - type: volume
               source: sbh

--- a/docker-compose.sboldb.yml
+++ b/docker-compose.sboldb.yml
@@ -35,7 +35,7 @@ services:
               target: /var/lib/postgresql/data
         restart: always
     sboldb-migrate:
-        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.2@sha256:e6bf296de9c170f69c2e87a1dcaa01f2a6d6de5941907e2860b3e6065d35edcd}
+        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.2}
         depends_on:
             postgres:
                 condition: service_healthy
@@ -44,7 +44,7 @@ services:
         command: ["db", "migrate"]
         restart: "no"
     sboldb:
-        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.2@sha256:e6bf296de9c170f69c2e87a1dcaa01f2a6d6de5941907e2860b3e6065d35edcd}
+        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.2}
         depends_on:
             sboldb-migrate:
                 condition: service_completed_successfully

--- a/docker-compose.sboldb.yml
+++ b/docker-compose.sboldb.yml
@@ -35,7 +35,7 @@ services:
               target: /var/lib/postgresql/data
         restart: always
     sboldb-migrate:
-        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.1}
+        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.2@sha256:e6bf296de9c170f69c2e87a1dcaa01f2a6d6de5941907e2860b3e6065d35edcd}
         depends_on:
             postgres:
                 condition: service_healthy
@@ -44,7 +44,7 @@ services:
         command: ["db", "migrate"]
         restart: "no"
     sboldb:
-        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.1}
+        image: ${SBOLDB_IMAGE:-ghcr.io/marpaia/sbol-db:v0.1.2@sha256:e6bf296de9c170f69c2e87a1dcaa01f2a6d6de5941907e2860b3e6065d35edcd}
         depends_on:
             sboldb-migrate:
                 condition: service_completed_successfully

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 services:
     autoheal: 
         restart: always
-        image: willfarrell/autoheal
+        image: ${AUTOHEAL_IMAGE:-willfarrell/autoheal}
         environment: 
             - AUTOHEAL_CONTAINER_LABEL=all
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
     virtuoso:
-        image: tenforce/virtuoso:virtuoso7.2.5
+        image: ${VIRTUOSO_IMAGE:-tenforce/virtuoso:virtuoso7.2.5}
         environment:
             - VIRT_SPARQL_MaxQueryCostEstimationTime=default
             - VIRT_SPARQL_MaxQueryExecutionTime=300
@@ -18,14 +18,14 @@ services:
               source: virtuoso-db
               target: /data
         ports:
-            - "8890:8890"
+            - "${TRIPLESTORE_PORT:-8890}:8890"
         restart: always  
     synbiohub:
-        image: synbiohub/synbiohub:snapshot-standalone
+        image: ${SYNBIOHUB_IMAGE:-synbiohub/synbiohub:snapshot-standalone}
         depends_on: 
             - virtuoso
         ports:
-            - "7777:7777"
+            - "${SYNBIOHUB_PORT:-7777}:7777"
         volumes:
             - type: volume
               source: sbh


### PR DESCRIPTION
This PR adds docker compose files which aim to allow for pluggable testing of sbol-db vs SBOLExplorer similarly to how we test sbol-db vs Virtuoso.